### PR TITLE
Refactor client UI panel composition

### DIFF
--- a/src/client/ui/components/hud/panel_manager.py
+++ b/src/client/ui/components/hud/panel_manager.py
@@ -1,51 +1,108 @@
-from dataclasses import dataclass, field
-from typing import Any, Protocol, Dict, List
+from __future__ import annotations
 
-class Renderable(Protocol):
-    def render(self, state: Any, **kwargs) -> bool: ...
+import logging
+from dataclasses import dataclass
+from typing import Callable, Dict, List
+
+from src.client.ui.core.panel_context import PanelRenderable, PanelRenderContext
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PanelSpec:
+    id: str
+    factory: Callable[[], PanelRenderable]
+    icon: str = ""
+    color: tuple = (1, 1, 1, 1)
+    default_visible: bool = False
+    show_in_toggle_bar: bool = True
+
 
 @dataclass
 class PanelEntry:
     id: str
-    instance: Renderable
+    instance: PanelRenderable
     visible: bool
     icon: str = ""
-    color: tuple = (1,1,1,1)
+    color: tuple = (1, 1, 1, 1)
+    show_in_toggle_bar: bool = True
+
 
 class PanelManager:
-    """
-    Manages the lifecycle and visibility of UI panels via Composition.
-    """
+    """Owns panel instances, visibility, and safe frame rendering."""
+
     def __init__(self):
         self._panels: Dict[str, PanelEntry] = {}
 
-    def register(self, pid: str, panel: Renderable, icon: str = "", color: tuple = None, visible: bool = False):
-        self._panels[pid] = PanelEntry(pid, panel, visible, icon, color or (1,1,1,1))
+    def register(
+        self,
+        pid: str,
+        panel: PanelRenderable,
+        icon: str = "",
+        color: tuple | None = None,
+        visible: bool = False,
+        show_in_toggle_bar: bool = True,
+    ) -> None:
+        self._panels[pid] = PanelEntry(
+            id=pid,
+            instance=panel,
+            visible=visible,
+            icon=icon,
+            color=color or (1, 1, 1, 1),
+            show_in_toggle_bar=show_in_toggle_bar,
+        )
 
-    def toggle(self, pid: str):
-        if pid in self._panels:
-            self._panels[pid].visible = not self._panels[pid].visible
+    def register_spec(self, spec: PanelSpec) -> None:
+        self.register(
+            spec.id,
+            spec.factory(),
+            icon=spec.icon,
+            color=spec.color,
+            visible=spec.default_visible,
+            show_in_toggle_bar=spec.show_in_toggle_bar,
+        )
 
-    def set_visible(self, pid: str, is_visible: bool):
-        if pid in self._panels:
-            self._panels[pid].visible = is_visible
+    def toggle(self, pid: str) -> None:
+        entry = self._panels.get(pid)
+        if entry is not None:
+            entry.visible = not entry.visible
+
+    def set_visible(self, pid: str, is_visible: bool) -> None:
+        entry = self._panels.get(pid)
+        if entry is not None:
+            entry.visible = is_visible
 
     def is_visible(self, pid: str) -> bool:
-        return self._panels[pid].visible if pid in self._panels else False
+        entry = self._panels.get(pid)
+        return bool(entry and entry.visible)
 
-    def render_all(self, state: Any, **context):
-        """
-        Iterates registered panels. If visible, calls their render method.
-        Handles the close signal (return value False).
-        """
+    def render_all(self, state, context: PanelRenderContext) -> None:
+        """Render all visible panels without letting one broken panel kill the frame."""
         for entry in self._panels.values():
             if not entry.visible:
                 continue
-            
-            # The panel render method should return False if the user closed it via 'X'
-            keep_open = entry.instance.render(state, **context)
+
+            try:
+                keep_open = entry.instance.render(state, context)
+            except TypeError:
+                try:
+                    keep_open = entry.instance.render(state, **context.to_legacy_kwargs())
+                except TypeError:
+                    logger.exception("Panel '%s' has an incompatible render signature", entry.id)
+                    continue
+                except Exception:
+                    logger.exception("Panel '%s' failed during legacy render", entry.id)
+                    continue
+            except Exception:
+                logger.exception("Panel '%s' failed during render", entry.id)
+                continue
+
             if keep_open is False:
                 entry.visible = False
 
-    def get_entries(self) -> List[PanelEntry]:
-        return list(self._panels.values())
+    def get_entries(self, toggle_bar_only: bool = False) -> List[PanelEntry]:
+        entries = list(self._panels.values())
+        if toggle_bar_only:
+            return [entry for entry in entries if entry.show_in_toggle_bar]
+        return entries

--- a/src/client/ui/components/hud/toggle_bar.py
+++ b/src/client/ui/components/hud/toggle_bar.py
@@ -1,6 +1,8 @@
 from imgui_bundle import imgui
-from src.client.ui.core.theme import GAMETHEME
+
 from src.client.ui.components.hud.panel_manager import PanelManager
+from src.client.ui.core.primitives import UIPrimitives as Prims
+
 
 class ToggleBar:
     def __init__(self, panel_manager: PanelManager):
@@ -9,56 +11,28 @@ class ToggleBar:
     def render(self):
         viewport = imgui.get_main_viewport()
         pad_x, pad_y = 10.0, 10.0
-        
-        # Anchor Bottom-Left
+
         imgui.set_next_window_pos(
             imgui.ImVec2(pad_x, viewport.size.y - pad_y),
             imgui.Cond_.always,
-            imgui.ImVec2(0.0, 1.0)
+            imgui.ImVec2(0.0, 1.0),
         )
-        
-        flags = (imgui.WindowFlags_.no_decoration | 
-                 imgui.WindowFlags_.no_move | 
-                 imgui.WindowFlags_.always_auto_resize | 
-                 imgui.WindowFlags_.no_background)
+
+        flags = (
+            imgui.WindowFlags_.no_decoration
+            | imgui.WindowFlags_.no_move
+            | imgui.WindowFlags_.always_auto_resize
+            | imgui.WindowFlags_.no_background
+        )
 
         if imgui.begin("ToggleBar", True, flags):
-            entries = self.manager.get_entries()
-            
-            # Filter only those with icons
-            icon_entries = [e for e in entries if e.icon]
-            
-            for i, entry in enumerate(icon_entries):
-                if i > 0: imgui.same_line(0, 10)
-                
-                if self._draw_toggle(entry.icon, entry.color, entry.visible):
+            icon_entries = [entry for entry in self.manager.get_entries(toggle_bar_only=True) if entry.icon]
+
+            for index, entry in enumerate(icon_entries):
+                if index > 0:
+                    imgui.same_line(0, 10)
+
+                if Prims.icon_toggle(entry.icon, entry.color, entry.visible):
                     self.manager.toggle(entry.id)
-            
+
             imgui.end()
-
-    def _draw_toggle(self, icon: str, color: tuple, is_active: bool) -> bool:
-        bg = GAMETHEME.colors.interaction_active if is_active else GAMETHEME.colors.bg_input
-        imgui.push_style_color(imgui.Col_.button, bg)
-        imgui.push_style_var(imgui.StyleVar_.frame_rounding, 8.0)
-        
-        clicked = imgui.button(icon, (50, 50))
-        
-        imgui.pop_style_var()
-        imgui.pop_style_color()
-
-        # Draw Indicator Line if active
-        if is_active:
-            p_min = imgui.get_item_rect_min()
-            p_max = imgui.get_item_rect_max()
-            draw_list = imgui.get_window_draw_list()
-            
-            # Indicator color uses the panel's specific color
-            ind_col = imgui.get_color_u32((color[0], color[1], color[2], 1.0))
-            
-            draw_list.add_rect_filled(
-                (p_min.x + 5, p_max.y - 6), 
-                (p_max.x - 5, p_max.y - 2), 
-                ind_col, 2.0
-            )
-            
-        return clicked

--- a/src/client/ui/core/panel_context.py
+++ b/src/client/ui/core/panel_context.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, Protocol, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.client.services.network_client_service import NetworkClient
+
+
+@dataclass(frozen=True, slots=True)
+class PanelRenderContext:
+    """Frame-local context shared by HUD panels.
+
+    Keeping panel context in one typed object avoids fragile **kwargs coupling and
+    makes new panel dependencies explicit.
+    """
+
+    target_tag: str
+    is_own_country: bool
+    selected_region_id: Optional[int] = None
+    on_focus_request: Optional[Callable[[int], None]] = None
+    net_client: Optional["NetworkClient"] = None
+
+    def to_legacy_kwargs(self) -> dict[str, Any]:
+        return {
+            "target_tag": self.target_tag,
+            "is_own_country": self.is_own_country,
+            "selected_region_id": self.selected_region_id,
+            "on_focus_request": self.on_focus_request,
+            "net_client": self.net_client,
+        }
+
+
+class PanelRenderable(Protocol):
+    def render(self, state: Any, context: PanelRenderContext) -> bool: ...

--- a/src/client/ui/core/primitives.py
+++ b/src/client/ui/core/primitives.py
@@ -1,10 +1,9 @@
 from imgui_bundle import imgui
 from src.client.ui.core.theme import GAMETHEME
 
+
 class UIPrimitives:
-    """
-    Stateless functional UI elements (Widgets).
-    """
+    """Stateless functional UI widgets shared by panels and HUD components."""
 
     @staticmethod
     def header(label: str, show_bg: bool = True):
@@ -14,20 +13,20 @@ class UIPrimitives:
             w = imgui.get_content_region_avail().x
             h = 24.0
             draw_list = imgui.get_window_draw_list()
-            
+
             draw_list.add_rect_filled(
-                p, (p.x + w, p.y + h),
-                imgui.get_color_u32(GAMETHEME.colors.bg_input), 4.0
+                p,
+                (p.x + w, p.y + h),
+                imgui.get_color_u32(GAMETHEME.colors.bg_input),
+                4.0,
             )
-            
-            # Center text vertically
+
             text_size = imgui.calc_text_size(label)
             text_y = p.y + (h - text_size.y) / 2
-            
+
             imgui.set_cursor_screen_pos((p.x + 8, text_y))
             imgui.text_colored(GAMETHEME.colors.text_main, label)
-            
-            # Reset cursor for next item
+
             imgui.set_cursor_screen_pos((p.x, p.y + h + 5))
         else:
             imgui.text_colored(GAMETHEME.colors.text_main, label)
@@ -38,50 +37,83 @@ class UIPrimitives:
         """Draws a custom progress bar/meter."""
         if label:
             imgui.text(label)
-        
+
         w = imgui.get_content_region_avail().x
         p = imgui.get_cursor_screen_pos()
         draw_list = imgui.get_window_draw_list()
 
-        # Background Track
         draw_list.add_rect_filled(
-            p, (p.x + w, p.y + height),
-            imgui.get_color_u32(GAMETHEME.colors.bg_input), height / 2
+            p,
+            (p.x + w, p.y + height),
+            imgui.get_color_u32(GAMETHEME.colors.bg_input),
+            height / 2,
         )
 
-        # Foreground Fill
         fraction = max(0.0, min(value_pct, 100.0)) / 100.0
         if fraction > 0.01:
             draw_list.add_rect_filled(
-                p, (p.x + w * fraction, p.y + height),
-                imgui.get_color_u32(color), height / 2
+                p,
+                (p.x + w * fraction, p.y + height),
+                imgui.get_color_u32(color),
+                height / 2,
             )
-        
+
         imgui.dummy((0, height + 5))
 
     @staticmethod
-    def currency_row(label: str, value: float, color: tuple = None):
+    def currency_row(label: str, value: float, color: tuple | None = None):
         """Aligned row: Label ...... $Value."""
         imgui.text(label)
         imgui.same_line()
-        
+
         val_str = f"$ {value:,.0f}".replace(",", " ")
-        width = imgui.calc_text_size(val_str).x
-        
-        # Right align
-        avail_w = imgui.get_content_region_avail().x
-        if avail_w > width:
-            imgui.set_cursor_pos_x(imgui.get_cursor_pos_x() + avail_w - width)
-        
         col = color if color else GAMETHEME.colors.text_main
-        imgui.text_colored(col, val_str)
+        UIPrimitives.right_align_text(val_str, col)
 
     @staticmethod
-    def right_align_text(text: str, color: tuple = None):
+    def right_align_text(text: str, color: tuple | None = None):
         width = imgui.calc_text_size(text).x
         avail_w = imgui.get_content_region_avail().x
-        imgui.set_cursor_pos_x(imgui.get_cursor_pos_x() + avail_w - width)
+        offset = max(0.0, avail_w - width)
+        if offset:
+            imgui.set_cursor_pos_x(imgui.get_cursor_pos_x() + offset)
+
         if color:
             imgui.text_colored(color, text)
         else:
             imgui.text(text)
+
+    @staticmethod
+    def icon_toggle(
+        icon: str,
+        color: tuple,
+        is_active: bool,
+        width: float = 50,
+        height: float = 50,
+        show_inactive_indicator: bool = False,
+    ) -> bool:
+        """Draws a square icon toggle with an optional bottom indicator."""
+        bg = GAMETHEME.colors.interaction_active if is_active else GAMETHEME.colors.bg_input
+        imgui.push_style_color(imgui.Col_.button, bg)
+        imgui.push_style_var(imgui.StyleVar_.frame_rounding, 8.0)
+
+        clicked = imgui.button(icon, (width, height))
+
+        imgui.pop_style_var()
+        imgui.pop_style_color()
+
+        if is_active or show_inactive_indicator:
+            p_min = imgui.get_item_rect_min()
+            p_max = imgui.get_item_rect_max()
+            draw_list = imgui.get_window_draw_list()
+            indicator_color = color if is_active else GAMETHEME.colors.text_dim
+            ind_col = imgui.get_color_u32((indicator_color[0], indicator_color[1], indicator_color[2], 1.0))
+
+            draw_list.add_rect_filled(
+                (p_min.x + 5, p_max.y - 6),
+                (p_max.x - 5, p_max.y - 2),
+                ind_col,
+                2.0,
+            )
+
+        return clicked

--- a/src/client/ui/layouts/game_layout.py
+++ b/src/client/ui/layouts/game_layout.py
@@ -1,69 +1,38 @@
 from typing import Optional
+
 import polars as pl
-from imgui_bundle import imgui, icons_fontawesome_6
+from imgui_bundle import imgui
 
 from src.client.services.network_client_service import NetworkClient
-from src.client.ui.core.theme import GAMETHEME
-from src.client.ui.core.composer import UIComposer
-
-# Components
 from src.client.ui.components.hud.central_bar import CentralBar
+from src.client.ui.components.hud.context_menu import ContextMenu
+from src.client.ui.components.hud.panel_manager import PanelManager
 from src.client.ui.components.hud.system_bar import SystemBar
 from src.client.ui.components.hud.toggle_bar import ToggleBar
-from src.client.ui.components.hud.panel_manager import PanelManager
-from src.client.ui.components.hud.context_menu import ContextMenu  # <--- NEW IMPORT
+from src.client.ui.core.composer import UIComposer
+from src.client.ui.core.panel_context import PanelRenderContext
+from src.client.ui.core.theme import GAMETHEME
+from src.client.ui.layouts.game_panel_registry import build_game_panel_specs
 
-# Panels
-from src.client.ui.panels.economy_panel import EconomyPanel
-from src.client.ui.panels.politics_panel import PoliticsPanel
-from src.client.ui.panels.military_panel import MilitaryPanel
-from src.client.ui.panels.demographics_panel import DemographicsPanel
-from src.client.ui.panels.region_inspector import RegionInspectorPanel
-from src.client.ui.panels.data_insp_panel import DataInspectorPanel
-from src.client.ui.panels.resources_panel import ResourcesPanel
-from src.client.ui.panels.budget_panel import BudgetPanel
 
 class GameLayout:
-    """
-    Composition root for the Game HUD.
-    """
+    """Composition root for the Game HUD."""
+
     def __init__(self, net_client: NetworkClient, player_tag: str, viewport_ctrl):
         self.net = net_client
         self.local_player_tag = player_tag
         self.viewport_ctrl = viewport_ctrl
 
         self.composer = UIComposer(GAMETHEME)
-
-        # 1. Compose Managers
         self.panel_manager = PanelManager()
-        
-        # 2. Register Panels
-        self.panel_manager.register("POL", PoliticsPanel(), icons_fontawesome_6.ICON_FA_BUILDING_COLUMNS, GAMETHEME.colors.politics)
-        self.panel_manager.register("MIL", MilitaryPanel(), icons_fontawesome_6.ICON_FA_PERSON_MILITARY_RIFLE, GAMETHEME.colors.military)
-        
-        # Economy Panel with callback to open Resources
-        self.panel_manager.register("ECO", EconomyPanel(
-            toggle_resources_cb=lambda: self.panel_manager.toggle("RESOURCES"),
-            toggle_budget_cb=lambda: self.panel_manager.toggle("BUDGET")
-        ), icons_fontawesome_6.ICON_FA_SACK_DOLLAR, GAMETHEME.colors.economy)
-        
-        self.panel_manager.register("DEM", DemographicsPanel(), icons_fontawesome_6.ICON_FA_PEOPLE_GROUP, GAMETHEME.colors.demographics)
-        self.panel_manager.register("INSPECTOR", RegionInspectorPanel())
-        self.panel_manager.register("DATA_INSPECTOR", DataInspectorPanel())
-        
-        # Resources Panel (no icon = won't appear in toggle bar)
-        self.panel_manager.register("RESOURCES", ResourcesPanel())
-        self.panel_manager.register("BUDGET", BudgetPanel())
+        for spec in build_game_panel_specs(self.panel_manager):
+            self.panel_manager.register_spec(spec)
 
-        # 3. Compose HUD Components
         self.central_bar = CentralBar()
         self.system_bar = SystemBar()
         self.toggle_bar = ToggleBar(self.panel_manager)
-        
-        # --- NEW: Context Menu Component ---
         self.context_menu = ContextMenu(self.composer, self.panel_manager, self.viewport_ctrl)
 
-        # State Cache
         self._last_selected_id: Optional[int] = None
         self._cached_target_tag: str = player_tag
 
@@ -71,35 +40,29 @@ class GameLayout:
         GAMETHEME.apply()
         state = self.net.get_state()
 
-        # Logic: Determine context
         target_tag, is_own = self._resolve_active_context(state, selected_region_id)
 
-        # Render Components
         self.system_bar.render(self.net, nav_service)
-        
+
         req_tag = self.central_bar.render(state, self.net, target_tag, is_own)
         if req_tag:
             self._cached_target_tag = req_tag
 
         self.toggle_bar.render()
 
-        # Render Panels
-        self.panel_manager.render_all(
-            state, 
-            target_tag=target_tag, 
+        panel_context = PanelRenderContext(
+            target_tag=target_tag,
             is_own_country=is_own,
             selected_region_id=selected_region_id,
             on_focus_request=self._on_focus_region,
-            net_client=self.net
+            net_client=self.net,
         )
+        self.panel_manager.render_all(state, panel_context)
 
-        # Render Context Menu
         self.context_menu.render()
-
         self._render_fps(fps)
 
     def show_context_menu(self, region_id: int):
-        """Delegates to the ContextMenu component."""
         self.context_menu.show(region_id)
 
     def _on_focus_region(self, region_id):
@@ -107,13 +70,15 @@ class GameLayout:
 
     def _render_fps(self, fps: float):
         imgui.set_next_window_pos((10, 10))
-        flags = (imgui.WindowFlags_.no_decoration | 
-                 imgui.WindowFlags_.no_inputs | 
-                 imgui.WindowFlags_.no_background | 
-                 imgui.WindowFlags_.always_auto_resize)
-        
+        flags = (
+            imgui.WindowFlags_.no_decoration
+            | imgui.WindowFlags_.no_inputs
+            | imgui.WindowFlags_.no_background
+            | imgui.WindowFlags_.always_auto_resize
+        )
+
         if imgui.begin("##FPS", True, flags):
-            imgui.text_colored((1,1,1,1), f"{fps:.0f}")
+            imgui.text_colored((1, 1, 1, 1), f"{fps:.0f}")
         imgui.end()
 
     def _resolve_active_context(self, state, region_id: Optional[int]) -> tuple[str, bool]:
@@ -121,14 +86,11 @@ class GameLayout:
             self._last_selected_id = region_id
             if not region_id:
                 self._cached_target_tag = self.local_player_tag
-            else:
-                if "regions" in state.tables:
-                    try:
-                        owner = state.tables["regions"] \
-                            .filter(pl.col("id") == region_id) \
-                            .item(0, "owner")
-                        self._cached_target_tag = owner if owner and owner != "None" else self.local_player_tag
-                    except Exception:
-                        self._cached_target_tag = self.local_player_tag
+            elif "regions" in state.tables:
+                try:
+                    owner = state.tables["regions"].filter(pl.col("id") == region_id).item(0, "owner")
+                    self._cached_target_tag = owner if owner and owner != "None" else self.local_player_tag
+                except Exception:
+                    self._cached_target_tag = self.local_player_tag
 
-        return self._cached_target_tag, (self._cached_target_tag == self.local_player_tag)
+        return self._cached_target_tag, self._cached_target_tag == self.local_player_tag

--- a/src/client/ui/layouts/game_panel_registry.py
+++ b/src/client/ui/layouts/game_panel_registry.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from imgui_bundle import icons_fontawesome_6
+
+from src.client.ui.components.hud.panel_manager import PanelManager, PanelSpec
+from src.client.ui.core.theme import GAMETHEME
+from src.client.ui.panels.budget_panel import BudgetPanel
+from src.client.ui.panels.data_insp_panel import DataInspectorPanel
+from src.client.ui.panels.demographics_panel import DemographicsPanel
+from src.client.ui.panels.economy_panel import EconomyPanel
+from src.client.ui.panels.military_panel import MilitaryPanel
+from src.client.ui.panels.politics_panel import PoliticsPanel
+from src.client.ui.panels.region_inspector import RegionInspectorPanel
+from src.client.ui.panels.resources_panel import ResourcesPanel
+
+
+def build_game_panel_specs(panel_manager: PanelManager) -> list[PanelSpec]:
+    """Declarative registry for the main in-game HUD panels."""
+    return [
+        PanelSpec(
+            id="POL",
+            factory=PoliticsPanel,
+            icon=icons_fontawesome_6.ICON_FA_BUILDING_COLUMNS,
+            color=GAMETHEME.colors.politics,
+        ),
+        PanelSpec(
+            id="MIL",
+            factory=MilitaryPanel,
+            icon=icons_fontawesome_6.ICON_FA_PERSON_MILITARY_RIFLE,
+            color=GAMETHEME.colors.military,
+        ),
+        PanelSpec(
+            id="ECO",
+            factory=lambda: EconomyPanel(
+                toggle_resources_cb=lambda: panel_manager.toggle("RESOURCES"),
+                toggle_budget_cb=lambda: panel_manager.toggle("BUDGET"),
+            ),
+            icon=icons_fontawesome_6.ICON_FA_SACK_DOLLAR,
+            color=GAMETHEME.colors.economy,
+        ),
+        PanelSpec(
+            id="DEM",
+            factory=DemographicsPanel,
+            icon=icons_fontawesome_6.ICON_FA_PEOPLE_GROUP,
+            color=GAMETHEME.colors.demographics,
+        ),
+        PanelSpec(
+            id="INSPECTOR",
+            factory=RegionInspectorPanel,
+            show_in_toggle_bar=False,
+        ),
+        PanelSpec(
+            id="DATA_INSPECTOR",
+            factory=DataInspectorPanel,
+            show_in_toggle_bar=False,
+        ),
+        PanelSpec(
+            id="RESOURCES",
+            factory=ResourcesPanel,
+            show_in_toggle_bar=False,
+        ),
+        PanelSpec(
+            id="BUDGET",
+            factory=BudgetPanel,
+            show_in_toggle_bar=False,
+        ),
+    ]


### PR DESCRIPTION
## Summary

Refactors the client UI panel composition layer to reduce duplication, make panel registration extensible, and improve runtime reliability.

### Changes

- Added `PanelRenderContext` as a typed frame-local context for HUD panels.
- Added `PanelSpec` and registry-based panel registration for the main game HUD.
- Refactored `PanelManager` to:
  - register declarative panel specs,
  - keep legacy `**kwargs` panel rendering compatible,
  - isolate panel render failures so one broken panel no longer kills the full frame,
  - support hiding non-toolbar panels from `ToggleBar`.
- Moved game panel registration out of `GameLayout` into `game_panel_registry.py`.
- Updated `GameLayout` to create one typed `PanelRenderContext` per frame.
- Consolidated the icon toggle drawing into `UIPrimitives.icon_toggle()` and reused it in `ToggleBar`.
- Hardened `UIPrimitives.right_align_text()` against negative cursor offsets.

## Validation

- Locally syntax-checked the refactored files with `python -m py_compile` before uploading.
- Did not run the full Arcade/ImGui application in this environment.

## Notes

This PR intentionally avoids a large all-at-once rewrite. Existing panels that still use `render(state, **kwargs)` remain supported via a compatibility fallback. New or migrated panels can use `render(state, context: PanelRenderContext)` directly.